### PR TITLE
fixes #830 - Help me with apoc (mongodb)

### DIFF
--- a/src/main/java/apoc/mongodb/MongoDBColl.java
+++ b/src/main/java/apoc/mongodb/MongoDBColl.java
@@ -144,4 +144,13 @@ class MongoDBColl implements MongoDB.Coll {
         DeleteResult result = collection.deleteMany(new Document(query));
         return result.wasAcknowledged() ? result.getDeletedCount() : -result.getDeletedCount();
     }
+
+    @Override
+    public void safeClose() {
+        try{
+            this.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
 }


### PR DESCRIPTION
Start a MongoDB with docker:
```
docker run --name apoc-mongo  mongo -p 27017:27017
docker exec -it apoc-mongo bash
>mongo
```
To check the number of opened connection you can use the command (inside the mongo shell)
`db.serverStatus().connections`

Check the number of connection using the current API for mongodb
```
CALL apoc.mongodb.get('localhost:27017','myDb','myColl',{x:1}) yield value return value
CALL apoc.mongodb.count('localhost:27017','myDb','myColl',{x:1}) yield value
CALL apoc.mongodb.first('localhost:27017','myDb','myColl',{x:1}) yield value
CALL apoc.mongodb.find('localhost:27017','myDb','myColl',{x:1},null,null) yield value
CALL apoc.mongodb.insert('localhost:27017','myDb','myColl',[{y:1}])
CALL apoc.mongodb.update('localhost:27017','myDb','myColl',{y:1}, apoc.map.fromPairs([['$set',{status: 'updated' }]]))
CALL apoc.mongodb.delete('localhost:27017','myDb','myColl',{y:1})
```